### PR TITLE
Replace ruby193-ruby with tfm-ruby

### DIFF
--- a/ansible/roles/passenger_nginx/vars/CentOS7.yml
+++ b/ansible/roles/passenger_nginx/vars/CentOS7.yml
@@ -8,7 +8,7 @@ passenger_nginx_default_site: /etc/nginx/conf.d/passenger.conf
 passenger_nginx_user: nginx
 
 passenger_nginx_passenger_root: /usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini
-passenger_nginx_passenger_ruby: /usr/bin/ruby193-ruby
+passenger_nginx_passenger_ruby: /usr/bin/tfm-ruby
 passenger_nginx_passenger_registry: /var/run/passenger-instreg
 passenger_nginx_passenger_app_root: /usr/share/foreman/public
 

--- a/ansible/roles/passenger_nginx/vars/RedHat.yml
+++ b/ansible/roles/passenger_nginx/vars/RedHat.yml
@@ -8,7 +8,7 @@ passenger_nginx_default_site: /etc/nginx/conf.d/passenger.conf
 passenger_nginx_user: nginx
 
 passenger_nginx_passenger_root: /usr/lib/ruby/1.8/phusion_passenger/locations.ini
-passenger_nginx_passenger_ruby: /usr/bin/ruby193-ruby
+passenger_nginx_passenger_ruby: /usr/bin/tfm-ruby
 passenger_nginx_passenger_registry: /var/run/passenger-instreg
 passenger_nginx_passenger_app_root: /usr/share/foreman/public
 

--- a/ansible/roles/passenger_nginx/vars/RedHat7.yml
+++ b/ansible/roles/passenger_nginx/vars/RedHat7.yml
@@ -8,7 +8,7 @@ passenger_nginx_default_site: /etc/nginx/conf.d/passenger.conf
 passenger_nginx_user: nginx
 
 passenger_nginx_passenger_root: /usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini
-passenger_nginx_passenger_ruby: /usr/bin/ruby193-ruby
+passenger_nginx_passenger_ruby: /usr/bin/tfm-ruby
 passenger_nginx_passenger_registry: /var/run/passenger-instreg
 passenger_nginx_passenger_app_root: /usr/share/foreman/public
 


### PR DESCRIPTION
Newer rpm packages of tfm-runtime use tfm-ruby instead of ruby193-ruby