### PR TITLE
Install tfm-ror51 repo on RHEL

### DIFF
--- a/ansible/roles/foreman/defaults/main.yml
+++ b/ansible/roles/foreman/defaults/main.yml
@@ -15,11 +15,16 @@ foreman_yum_main_baseurl: "http://yum.theforeman.org/releases/latest/el{{ ansibl
 foreman_yum_main_gpg: 1
 foreman_yum_main_key: "http://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman"
 
+foreman_yum_ror51_baseurl: "https://copr-be.cloud.fedoraproject.org/results/@theforeman/tfm-ror51/epel-{{ ansible_distribution_major_version }}-$basearch/"
+foreman_yum_ror51_gpg: 1
+foreman_yum_ror51_key: "https://copr-be.cloud.fedoraproject.org/results/@theforeman/tfm-ror51/pubkey.gpg"
+
 foreman_yum_plugins_baseurl: "http://yum.theforeman.org/plugins/latest/el{{ ansible_distribution_major_version }}/$basearch/"
 foreman_yum_plugins_gpg: 1
 foreman_yum_plugins_key: "http://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman"
 
 foreman_plugins_repo: true
+foreman_ror51_repo: true
 foreman_enable_service: false
 
 foreman_db_adapter: mysql2

--- a/ansible/roles/foreman/tasks/repository.yml
+++ b/ansible/roles/foreman/tasks/repository.yml
@@ -47,6 +47,18 @@
     dest=/etc/yum.repos.d/foreman_plugins.repo
   when: ansible_os_family == "RedHat" and foreman_plugins_repo 
 
+- name: configure foreman ror51 rpm key
+  rpm_key:
+    key="{{ foreman_yum_ror51_key }}"
+    state=present
+  when: ansible_distribution == "RedHat" and foreman_yum_ror51_gpg and foreman_ror51_repo
+
+- name: configure foreman ror51 yum repository
+  template:
+    src=foreman_ror51.repo.j2
+    dest=/etc/yum.repos.d/foreman_ror51.repo
+  when: ansible_distribution == "RedHat" and foreman_ror51_repo
+
 - name: configure additional repositories
   package:
     name="{{ item }}"

--- a/ansible/roles/foreman/vars/RedHat.yml
+++ b/ansible/roles/foreman/vars/RedHat.yml
@@ -2,7 +2,6 @@
 foreman_pkg: foreman
 foreman_extra_repos_pkg:
   - "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
-  - foreman-release-scl
 
 foreman_db_sqlite_adapter_pkg: foreman-sqlite
 foreman_db_mysql_adapter_pkg: foreman-mysql2

--- a/ansible/roles/foreman/vars/RedHat7.yml
+++ b/ansible/roles/foreman/vars/RedHat7.yml
@@ -2,7 +2,6 @@
 foreman_pkg: foreman
 foreman_extra_repos_pkg:
   - "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-  - foreman-release-scl
 
 foreman_db_sqlite_adapter_pkg: foreman-sqlite
 foreman_db_mysql_adapter_pkg: foreman-mysql2


### PR DESCRIPTION
The `foreman-release-scl` package add 3 repositories:

* CentOS SCL
* CentOS RH SCL
* Foreman ror51 (custom rubygem packages)

The documentation is not very clear how to handle this properly on RHEL but just suggests to install `foreman-release-scl` instead. IMHO it's not optimal to mix CentOS SCL and RHEL SCL. This PR solely adds the ror51 repo instead of installing `foreman-release-scl` on RHEL.