### PR TITLE
[WIP] Allow configuration of custom CA certificate for Foreman LDAP connection

### DIFF
--- a/ansible/roles/foreman/defaults/main.yml
+++ b/ansible/roles/foreman/defaults/main.yml
@@ -22,6 +22,10 @@ foreman_yum_plugins_key: "http://yum.theforeman.org/releases/latest/RPM-GPG-KEY-
 foreman_plugins_repo: true
 foreman_enable_service: false
 
+foreman_ldap: false
+foreman_ldap_cert:
+foreman_ldap_cert_file: example_com_ldap_ca_cert.crt
+
 foreman_db_adapter: mysql2
 foreman_db_name: foreman
 foreman_db_sqlite_dir: /var/lib/foreman/db

--- a/ansible/roles/foreman/tasks/configuration.yml
+++ b/ansible/roles/foreman/tasks/configuration.yml
@@ -22,10 +22,6 @@
   when: foreman_ldap
   register: foreman_register_ldap
 
-- name: trigger update-ca-trust
-  command: /bin/update-ca-trust
-  when: ansible_os_family == "RedHat" and foreman_ldap and foreman_register_ldap.changed
-
-- name: trigger update-ca-certificates
-  command: /usr/sbin/update-ca-certificates
-  when: ansible_os_family == "Debian" and foreman_ldap and foreman_register_ldap.changed
+- name: update ca certificates bundle
+  command: "{{ foreman_ca_update_bin }}"
+  when: foreman_ldap and foreman_register_ldap.changed

--- a/ansible/roles/foreman/tasks/configuration.yml
+++ b/ansible/roles/foreman/tasks/configuration.yml
@@ -11,3 +11,21 @@
     regexp="START=no"
     replace="START=yes"
   when: ansible_os_family == "Debian" and foreman_enable_service
+
+- name: configure ldap certificate
+  copy:
+    content="{{ foreman_ldap_cert }}"
+    dest="{{ foreman_ldap_cert_dir }}/{{ foreman_ldap_cert_file }}"
+    owner=root
+    group=root
+    mode=0644
+  when: foreman_ldap
+  register: foreman_register_ldap
+
+- name: trigger update-ca-trust
+  command: /bin/update-ca-trust
+  when: ansible_os_family == "RedHat" and foreman_ldap and foreman_register_ldap.changed
+
+- name: trigger update-ca-certificates
+  command: /usr/sbin/update-ca-certificates
+  when: ansible_os_family == "Debian" and foreman_ldap and foreman_register_ldap.changed

--- a/ansible/roles/foreman/vars/CentOS6.yml
+++ b/ansible/roles/foreman/vars/CentOS6.yml
@@ -11,3 +11,5 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 foreman_db_socket: /var/lib/mysql/mysql.sock 
 
 foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors
+
+foreman_ca_update_bin: /bin/update-ca-trust

--- a/ansible/roles/foreman/vars/CentOS6.yml
+++ b/ansible/roles/foreman/vars/CentOS6.yml
@@ -9,3 +9,5 @@ foreman_db_mysql_adapter_pkg: foreman-mysql2
 foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/lib/mysql/mysql.sock 
+
+foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors

--- a/ansible/roles/foreman/vars/CentOS7.yml
+++ b/ansible/roles/foreman/vars/CentOS7.yml
@@ -11,3 +11,5 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 foreman_db_socket: /var/lib/mysql/mysql.sock 
 
 foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors
+
+foreman_ca_update_bin: /bin/update-ca-trust

--- a/ansible/roles/foreman/vars/CentOS7.yml
+++ b/ansible/roles/foreman/vars/CentOS7.yml
@@ -9,3 +9,5 @@ foreman_db_mysql_adapter_pkg: foreman-mysql2
 foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/lib/mysql/mysql.sock 
+
+foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors

--- a/ansible/roles/foreman/vars/Debian.yml
+++ b/ansible/roles/foreman/vars/Debian.yml
@@ -9,3 +9,5 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 foreman_db_socket: /var/run/mysqld/mysqld.sock
 
 foreman_ldap_cert_dir: /usr/loca/share/ca-certificates
+
+foreman_ca_update_bin: /usr/sbin/update-ca-certificates

--- a/ansible/roles/foreman/vars/Debian.yml
+++ b/ansible/roles/foreman/vars/Debian.yml
@@ -8,6 +8,6 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/run/mysqld/mysqld.sock
 
-foreman_ldap_cert_dir: /usr/loca/share/ca-certificates
+foreman_ldap_cert_dir: /usr/local/share/ca-certificates
 
 foreman_ca_update_bin: /usr/sbin/update-ca-certificates

--- a/ansible/roles/foreman/vars/Debian.yml
+++ b/ansible/roles/foreman/vars/Debian.yml
@@ -7,3 +7,5 @@ foreman_db_mysql_adapter_pkg: foreman-mysql2
 foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/run/mysqld/mysqld.sock
+
+foreman_ldap_cert_dir: /usr/loca/share/ca-certificates

--- a/ansible/roles/foreman/vars/RedHat.yml
+++ b/ansible/roles/foreman/vars/RedHat.yml
@@ -11,3 +11,5 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 foreman_db_socket: /var/lib/mysql/mysql.sock 
 
 foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors
+
+foreman_ca_update_bin: /bin/update-ca-trust

--- a/ansible/roles/foreman/vars/RedHat.yml
+++ b/ansible/roles/foreman/vars/RedHat.yml
@@ -9,3 +9,5 @@ foreman_db_mysql_adapter_pkg: foreman-mysql2
 foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/lib/mysql/mysql.sock 
+
+foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors

--- a/ansible/roles/foreman/vars/RedHat7.yml
+++ b/ansible/roles/foreman/vars/RedHat7.yml
@@ -11,3 +11,5 @@ foreman_db_pgsql_adapter_pkg: foreman-postgresql
 foreman_db_socket: /var/lib/mysql/mysql.sock 
 
 foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors
+
+foreman_ca_update_bin: /bin/update-ca-trust

--- a/ansible/roles/foreman/vars/RedHat7.yml
+++ b/ansible/roles/foreman/vars/RedHat7.yml
@@ -9,3 +9,5 @@ foreman_db_mysql_adapter_pkg: foreman-mysql2
 foreman_db_pgsql_adapter_pkg: foreman-postgresql
 
 foreman_db_socket: /var/lib/mysql/mysql.sock 
+
+foreman_ldap_cert_dir: /etc/pki/ca-trust/source/anchors


### PR DESCRIPTION
Often LDAPS requires a self-signed certificate to be trusted. This PR will add the possibility to define custom CA certificates to be deployed into the system CA store.