### PR TITLE
Change '=' to ': ' in all Ansible tasks

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: update apt cache
   apt:
-    update_cache=yes
+    update_cache: yes
   when: ansible_pkg_mgr == "apt"

--- a/ansible/roles/foreman/tasks/configuration.yml
+++ b/ansible/roles/foreman/tasks/configuration.yml
@@ -1,13 +1,13 @@
 ---
 - name: template foreman settings.yaml
   template:
-    src=settings.yaml.j2
-    dest=/etc/foreman/settings.yaml
-    backup=yes
+    src: settings.yaml.j2
+    dest: /etc/foreman/settings.yaml
+    backup: yes
 
 - name: configure foreman init config
   replace:
-    dest=/etc/default/foreman
-    regexp="START=no"
-    replace="START=yes"
+    dest: /etc/default/foreman
+    regexp: "START=no"
+    replace: "START=yes"
   when: ansible_os_family == "Debian" and foreman_enable_service

--- a/ansible/roles/foreman/tasks/database.yml
+++ b/ansible/roles/foreman/tasks/database.yml
@@ -1,17 +1,17 @@
 ---
 - name: template foreman database.yml
   template:
-    src=database.yml.j2
-    dest=/etc/foreman/database.yml
-    backup=yes
+    src: database.yml.j2
+    dest: /etc/foreman/database.yml
+    backup: yes
 
 - name: set permissions for sqlite directory
   file:
-    path="{{ foreman_db_sqlite_dir }}"
-    owner=foreman
-    group=foreman
-    mode=0755
-    state=directory
+    path: "{{ foreman_db_sqlite_dir }}"
+    owner: foreman
+    group: foreman
+    mode: 0755
+    state: directory
   when: foreman_db_adapter == "sqlite3"
 
 - name: rake create foreman database
@@ -28,7 +28,7 @@
 
 - name: enable foreman service
   service:
-    name=foreman
-    enabled=yes
-    state=started
+    name: foreman
+    enabled: yes
+    state: started
   when: foreman_enable_service

--- a/ansible/roles/foreman/tasks/installation.yml
+++ b/ansible/roles/foreman/tasks/installation.yml
@@ -1,27 +1,27 @@
 ---
 - name: install foreman
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_pkg }}"
 
 - name: install foreman sqlite database adapter
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_db_sqlite_adapter_pkg }}"
   when: foreman_db_adapter == "sqlite3"
 
 - name: install foreman mysql database adapter
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_db_mysql_adapter_pkg }}"
   when: foreman_db_adapter == "mysql2"
 
 - name: install foreman postgresql database adapter
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_db_pgsql_adapter_pkg }}"
   when: foreman_db_adapter == "postgresql"

--- a/ansible/roles/foreman/tasks/repository.yml
+++ b/ansible/roles/foreman/tasks/repository.yml
@@ -1,66 +1,66 @@
 ---
 - name: configure foreman apt key
   apt_key:
-    url="{{ foreman_apt_main_key }}"
-    state=present
+    url: "{{ foreman_apt_main_key }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_apt_main_gpg
 
 - name: configure foreman apt repository
   apt_repository:
-    repo="deb {{ foreman_apt_main_baseurl }} {{ foreman_apt_main_os_version }} {{ foreman_apt_main_release }}"
-    state=present
+    repo: "deb {{ foreman_apt_main_baseurl }} {{ foreman_apt_main_os_version }} {{ foreman_apt_main_release }}"
+    state: present
   when: ansible_os_family == "Debian"
 
 - name: configure foreman plugins apt key
   apt_key:
-    url="{{ foreman_apt_plugins_key }}"
-    state=present
+    url: "{{ foreman_apt_plugins_key }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_apt_plugins_gpg and foreman_plugins_repo
 
 - name: configure foreman plugins apt repository
   apt_repository:
-    repo="deb {{ foreman_apt_plugins_baseurl }} {{ foreman_apt_plugins_os_version }} {{ foreman_apt_plugins_release }}"
-    state=present
+    repo: "deb {{ foreman_apt_plugins_baseurl }} {{ foreman_apt_plugins_os_version }} {{ foreman_apt_plugins_release }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_plugins_repo
 
 - name: configure foreman rpm key
   rpm_key:
-    key="{{ foreman_yum_main_key }}"
-    state=present
+    key: "{{ foreman_yum_main_key }}"
+    state: present
   when: ansible_os_family == "RedHat" and foreman_yum_main_gpg
 
 - name: configure foreman yum repository
   template:
-    src=foreman.repo.j2
-    dest=/etc/yum.repos.d/foreman.repo
+    src: foreman.repo.j2
+    dest: /etc/yum.repos.d/foreman.repo
   when: ansible_os_family == "RedHat"
 
 - name: configure foreman plugins rpm key
   rpm_key:
-    key="{{ foreman_yum_plugins_key }}"
-    state=present
+    key: "{{ foreman_yum_plugins_key }}"
+    state: present
   when: ansible_os_family == "RedHat" and foreman_yum_plugins_gpg and foreman_plugins_repo
 
 - name: configure foreman plugins yum repository
   template:
-    src=foreman_plugins.repo.j2
-    dest=/etc/yum.repos.d/foreman_plugins.repo
+    src: foreman_plugins.repo.j2
+    dest: /etc/yum.repos.d/foreman_plugins.repo
   when: ansible_os_family == "RedHat" and foreman_plugins_repo 
 
 - name: configure foreman ror51 rpm key
   rpm_key:
-    key="{{ foreman_yum_ror51_key }}"
-    state=present
+    key: "{{ foreman_yum_ror51_key }}"
+    state: present
   when: ansible_distribution == "RedHat" and foreman_yum_ror51_gpg and foreman_ror51_repo
 
 - name: configure foreman ror51 yum repository
   template:
-    src=foreman_ror51.repo.j2
-    dest=/etc/yum.repos.d/foreman_ror51.repo
+    src: foreman_ror51.repo.j2
+    dest: /etc/yum.repos.d/foreman_ror51.repo
   when: ansible_distribution == "RedHat" and foreman_ror51_repo
 
 - name: configure additional repositories
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_extra_repos_pkg }}"

--- a/ansible/roles/foreman_proxy/tasks/configuration.yml
+++ b/ansible/roles/foreman_proxy/tasks/configuration.yml
@@ -1,58 +1,58 @@
 ---
 - name: template foreman-proxy settings.yml
   template:
-    src=settings.yml.j2
-    dest=/etc/foreman-proxy/settings.yml
-    backup=yes
+    src: settings.yml.j2
+    dest: /etc/foreman-proxy/settings.yml
+    backup: yes
   notify:
     - restart foreman-proxy
 
 - name: template foreman-proxy dhcp.yml
   template:
-    src=dhcp.yml.j2
-    dest=/etc/foreman-proxy/settings.d/dhcp.yml
-    backup=yes
+    src: dhcp.yml.j2
+    dest: /etc/foreman-proxy/settings.d/dhcp.yml
+    backup: yes
   when: foreman_proxy_dhcp
   notify:
     - restart foreman-proxy
 
 - name: template foreman-proxy dhcp_isc.yml
   template:
-    src=dhcp_isc.yml.j2
-    dest=/etc/foreman-proxy/settings.d/dhcp_isc.yml
-    backup=yes
+    src: dhcp_isc.yml.j2
+    dest: /etc/foreman-proxy/settings.d/dhcp_isc.yml
+    backup: yes
   when: foreman_proxy_dhcp
   notify:
     - restart foreman-proxy
 
 - name: fix dhcp config directory permissions
   file:
-    path={{ foreman_proxy_dhcp_config_dir }}
-    mode=0755
-    state=directory
+    path: "{{ foreman_proxy_dhcp_config_dir }}"
+    mode: 0755
+    state: directory
   when: foreman_proxy_dhcp
   notify:
     - restart foreman-proxy
 
 - name: template foreman-proxy tftp.yaml
   template:
-    src=tftp.yml.j2
-    dest=/etc/foreman-proxy/settings.d/tftp.yml
-    backup=yes
+    src: tftp.yml.j2
+    dest: /etc/foreman-proxy/settings.d/tftp.yml
+    backup: yes
   when: foreman_proxy_tftp
   notify:
     - restart foreman-proxy
 
 - name: ensure correct permissions for tftp pxe directories
   file:
-    path="{{ foreman_proxy_tftp_dir }}/{{ item }}"
-    owner="{{ foreman_proxy_user }}"
-    group="{{ foreman_proxy_group }}"
-    state=directory
+    path: "{{ foreman_proxy_tftp_dir }}/{{ item }}"
+    owner: "{{ foreman_proxy_user }}"
+    group: "{{ foreman_proxy_group }}"
+    state: directory
   when: foreman_proxy_tftp
   with_items: "{{ foreman_proxy_tftp_pxe_dir }}"
 
 - name: start foreman-proxy service
   service:
-    name=foreman-proxy
-    state=started
+    name: foreman-proxy
+    state: started

--- a/ansible/roles/foreman_proxy/tasks/installation.yml
+++ b/ansible/roles/foreman_proxy/tasks/installation.yml
@@ -1,11 +1,11 @@
 ---
 - name: install foreman-proxy
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_proxy_pkg }}"
 
 - name: enable foreman-proxy service
   service:
-    name=foreman-proxy
-    enabled=yes
+    name: foreman-proxy
+    enabled: yes

--- a/ansible/roles/foreman_proxy/tasks/repository.yml
+++ b/ansible/roles/foreman_proxy/tasks/repository.yml
@@ -1,54 +1,54 @@
 ---
 - name: configure foreman apt key
   apt_key:
-    url="{{ foreman_proxy_apt_main_key }}"
-    state=present
+    url: "{{ foreman_proxy_apt_main_key }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_proxy_apt_main_gpg
 
 - name: configure foreman apt repository
   apt_repository:
-    repo="deb {{ foreman_proxy_apt_main_baseurl }} {{ foreman_proxy_apt_main_os_version }} {{ foreman_proxy_apt_main_release }}"
-    state=present
+    repo: "deb {{ foreman_proxy_apt_main_baseurl }} {{ foreman_proxy_apt_main_os_version }} {{ foreman_proxy_apt_main_release }}"
+    state: present
   when: ansible_os_family == "Debian"
 
 - name: configure foreman plugins apt key
   apt_key:
-    url="{{ foreman_proxy_apt_plugins_key }}"
-    state=present
+    url: "{{ foreman_proxy_apt_plugins_key }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_proxy_apt_plugins_gpg and foreman_proxy_plugins_repo
 
 - name: configure foreman plugins apt repository
   apt_repository:
-    repo="deb {{ foreman_proxy_apt_plugins_baseurl }} {{ foreman_proxy_apt_plugins_os_version }} {{ foreman_proxy_apt_plugins_release }}"
-    state=present
+    repo: "deb {{ foreman_proxy_apt_plugins_baseurl }} {{ foreman_proxy_apt_plugins_os_version }} {{ foreman_proxy_apt_plugins_release }}"
+    state: present
   when: ansible_os_family == "Debian" and foreman_proxy_plugins_repo
 
 - name: configure foreman rpm key
   rpm_key:
-    key="{{ foreman_proxy_yum_main_key }}"
-    state=present
+    key: "{{ foreman_proxy_yum_main_key }}"
+    state: present
   when: ansible_os_family == "RedHat" and foreman_proxy_yum_main_gpg
 
 - name: configure foreman yum repository
   template:
-    src=foreman.repo.j2
-    dest=/etc/yum.repos.d/foreman.repo
+    src: foreman.repo.j2
+    dest: /etc/yum.repos.d/foreman.repo
   when: ansible_os_family == "RedHat"
 
 - name: configure foreman plugins rpm key
   rpm_key:
-    key="{{ foreman_proxy_yum_plugins_key }}"
-    state=present
+    key: "{{ foreman_proxy_yum_plugins_key }}"
+    state: present
   when: ansible_os_family == "RedHat" and foreman_proxy_yum_plugins_gpg and foreman_proxy_plugins_repo
 
 - name: configure foreman plugins yum repository
   template:
-    src=foreman_plugins.repo.j2
-    dest=/etc/yum.repos.d/foreman_plugins.repo
+    src: foreman_plugins.repo.j2
+    dest: /etc/yum.repos.d/foreman_plugins.repo
   when: ansible_os_family == "RedHat" and foreman_proxy_plugins_repo 
 
 - name: configure additional repositories
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_proxy_extra_repos_pkg }}"

--- a/ansible/roles/foreman_yml/tasks/api_calls.yml
+++ b/ansible/roles/foreman_yml/tasks/api_calls.yml
@@ -5,14 +5,14 @@
 
 - name: install foreman-yml dependencies
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ foreman_yml_pkg }}"
 
 - name: copy foreman-yml files to the target machine
   copy:
-    src=foreman-yml
-    dest=/opt/
+    src: foreman-yml
+    dest: /opt/
 
 - name: python setup foreman-yml script
   command:
@@ -20,8 +20,8 @@
 
 - name: copy template to target machine
   copy:
-    content="{{ foreman_yml_config }}"
-    dest="/opt/foreman-yml/foreman_config.yml"
+    content: "{{ foreman_yml_config }}"
+    dest: "/opt/foreman-yml/foreman_config.yml"
 
 - name: configure foreman with foreman-yml
   shell:

--- a/ansible/roles/isc_dhcp_server/tasks/configuration.yml
+++ b/ansible/roles/isc_dhcp_server/tasks/configuration.yml
@@ -1,13 +1,13 @@
 ---
 - name: template isc-dhcp-server dhcpd.conf
   template:
-    src=dhcpd.conf.j2
-    dest=/etc/dhcp/dhcpd.conf
-    backup=yes
+    src: dhcpd.conf.j2
+    dest: /etc/dhcp/dhcpd.conf
+    backup: yes
   notify:
     - restart isc-dhcp-server
 
 - name: start isc-dhcp-server service
   service:
-    name="{{ isc_dhcp_server_service }}"
-    state=started
+    name: "{{ isc_dhcp_server_service }}"
+    state: started

--- a/ansible/roles/isc_dhcp_server/tasks/installation.yml
+++ b/ansible/roles/isc_dhcp_server/tasks/installation.yml
@@ -1,11 +1,11 @@
 ---
 - name: install isc-dhcp-server
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ isc_dhcp_server_pkg }}"
 
 - name: enable isc-dhcp-server service
   service:
-    name="{{ isc_dhcp_server_service }}"
-    enabled=yes
+    name: "{{ isc_dhcp_server_service }}"
+    enabled: yes

--- a/ansible/roles/mysql/tasks/configuration.yml
+++ b/ansible/roles/mysql/tasks/configuration.yml
@@ -1,17 +1,17 @@
 ---
 - name: create mysql databases
   mysql_db:
-    name="{{ item.name }}"
-    collation="{{ item.collation }}"
-    encoding="{{ item.encoding }}"
-    state=present
+    name: "{{ item.name }}"
+    collation: "{{ item.collation }}"
+    encoding: "{{ item.encoding }}"
+    state: present
   with_items: "{{ mysql_databases }}"
 
 - name: create mysql users
   mysql_user:
-    name="{{ item.name }}"
-    host="{{ item.host }}"
-    password="{{ item.password }}"
-    priv="{{ item.priv }}"
-    state=present
+    name: "{{ item.name }}"
+    host: "{{ item.host }}"
+    password: "{{ item.password }}"
+    priv: "{{ item.priv }}"
+    state: present
   with_items: "{{ mysql_users }}"

--- a/ansible/roles/mysql/tasks/installation.yml
+++ b/ansible/roles/mysql/tasks/installation.yml
@@ -1,17 +1,17 @@
 ---
 - name: install mysql
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ mysql_pkg }}"
   register: mysql_installed
 
 - name: enable mysql service
   service:
-    name="{{ mysql_service }}"
-    enabled=yes
+    name: "{{ mysql_service }}"
+    enabled: yes
 
 - name: start mysql service
   service:
-    name="{{ mysql_service }}"
-    state=started
+    name: "{{ mysql_service }}"
+    state: started

--- a/ansible/roles/mysql/tasks/secure_installation.yml
+++ b/ansible/roles/mysql/tasks/secure_installation.yml
@@ -1,29 +1,29 @@
 ---
 - name: update mysql root password for all root accounts
   mysql_user:
-    name=root
-    host="{{ item }}"
-    password="{{ mysql_root_password }}"
-    check_implicit_admin=yes
-    login_user="{{ mysql_root_username }}"
-    login_password="{{ mysql_root_password }}"
-    state=present
+    name: root
+    host: "{{ item }}"
+    password: "{{ mysql_root_password }}"
+    check_implicit_admin: yes
+    login_user: "{{ mysql_root_username }}"
+    login_password: "{{ mysql_root_password }}"
+    state: present
   with_items: "{{ mysql_root_user_hosts }}"
 
 - name: template .my.cnf
   template:
-    src=auth.my.cnf.j2
-    dest=/root/.my.cnf
-    mode=0640
+    src: auth.my.cnf.j2
+    dest: /root/.my.cnf
+    mode: 0640
 
 - name: remove anonymous mysql users
   mysql_user:
-    name=""
-    host="{{ item }}"
-    state=absent
+    name: ""
+    host: "{{ item }}"
+    state: absent
   with_items: "{{ mysql_anon_user_hosts }}"
 
 - name: remove test database
   mysql_db:
-    name=test
-    state=absent
+    name: test
+    state: absent

--- a/ansible/roles/nginx/tasks/configuration.yml
+++ b/ansible/roles/nginx/tasks/configuration.yml
@@ -1,27 +1,27 @@
 ---
 - name: template nginx.conf
   template:
-    src=nginx.conf.j2
-    dest=/etc/nginx/nginx.conf
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
   notify:
     - restart nginx
 
 - name: remove nginx default.conf
   file:
-    path="{{ item }}"
-    state=absent
+    path: "{{ item }}"
+    state: absent
   with_items: "{{ nginx_default_site }}"
   notify:
     - restart nginx
 
 - name: template nginx foreman.conf
   template:
-    src=foreman.conf.j2
-    dest="{{ nginx_cfg_dir }}/foreman.conf"
+    src: foreman.conf.j2
+    dest: "{{ nginx_cfg_dir }}/foreman.conf"
   notify:
     - restart nginx
 
 - name: restart nginx passenger
   service:
-    name=nginx
-    state=restarted
+    name: nginx
+    state: restarted

--- a/ansible/roles/nginx/tasks/installation.yml
+++ b/ansible/roles/nginx/tasks/installation.yml
@@ -1,11 +1,11 @@
 ---
 - name: install nginx
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ nginx_pkg }}"
 
 - name: enable nginx service
   service:
-    name=nginx
-    enabled=yes
+    name: nginx
+    enabled: yes

--- a/ansible/roles/nginx/tasks/repository.yml
+++ b/ansible/roles/nginx/tasks/repository.yml
@@ -1,36 +1,36 @@
 ---
 - name: configure upstream nginx apt key
   apt_key:
-    url="{{ nginx_upstream_repo_key }}"
-    state="{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
+    url: "{{ nginx_upstream_repo_key }}"
+    state: "{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
   when: ansible_os_family == "Debian"
 
 - name: configure upstream nginx apt repository
   apt_repository:
-    repo="deb {{ nginx_upstream_repo_baseurl }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx"
-    state="{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
+    repo: "deb {{ nginx_upstream_repo_baseurl }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx"
+    state: "{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
   when: ansible_os_family == "Debian"
 
 - name: configure upstream nginx rpm key
   rpm_key:
-    key="{{ nginx_upstream_repo_key }}"
-    state="{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
+    key: "{{ nginx_upstream_repo_key }}"
+    state: "{% if nginx_upstream_repo %}present{% else %}absent{% endif %}"
   when: ansible_os_family == "RedHat"
 
 - name: configure upstream nginx yum repository
   template:
-    src=nginx.repo.j2
-    dest=/etc/yum.repos.d/nginx.repo
+    src: nginx.repo.j2
+    dest: /etc/yum.repos.d/nginx.repo
   when: ansible_os_family == "RedHat" and nginx_upstream_repo
 
 - name: remove upstream nginx yum repository
   file:
-    path=/etc/yum.repos.d/nginx.repo
-    state=absent
+    path: /etc/yum.repos.d/nginx.repo
+    state: absent
   when: ansible_os_family == "RedHat" and not nginx_upstream_repo
 
 - name: configure centos epel yum repository
   yum:
-    name=epel-release
-    state="{% if not nginx_upstream_repo %}present{% else %}absent{% endif %}"
+    name: epel-release
+    state: "{% if not nginx_upstream_repo %}present{% else %}absent{% endif %}"
   when: ansible_distribution == "CentOS"

--- a/ansible/roles/passenger_nginx/tasks/configuration.yml
+++ b/ansible/roles/passenger_nginx/tasks/configuration.yml
@@ -1,27 +1,27 @@
 ---
 - name: template nginx.conf
   template:
-    src=nginx.conf.j2
-    dest=/etc/nginx/nginx.conf
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
   notify:
     - restart nginx
 
 - name: remove nginx default.conf
   file:
-    path="{{ item }}"
-    state=absent
+    path: "{{ item }}"
+    state: absent
   with_items: "{{ passenger_nginx_default_site }}"
   notify:
     - restart nginx
 
 - name: template nginx foreman.conf
   template:
-    src=foreman.conf.j2
-    dest="{{ passenger_nginx_cfg_dir }}/foreman.conf"
+    src: foreman.conf.j2
+    dest: "{{ passenger_nginx_cfg_dir }}/foreman.conf"
   notify:
     - restart nginx
 
 - name: restart nginx passenger
   service:
-    name=nginx
-    state=restarted
+    name: nginx
+    state: restarted

--- a/ansible/roles/passenger_nginx/tasks/installation.yml
+++ b/ansible/roles/passenger_nginx/tasks/installation.yml
@@ -1,11 +1,11 @@
 ---
 - name: install passenger nginx
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ passenger_nginx_pkg }}"
 
 - name: enable passenger nginx service
   service:
-    name=nginx
-    enabled=yes
+    name: nginx
+    enabled: yes

--- a/ansible/roles/passenger_nginx/tasks/repository.yml
+++ b/ansible/roles/passenger_nginx/tasks/repository.yml
@@ -1,50 +1,50 @@
 ---
 - name: install apt-transport-https
   apt:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ passenger_nginx_apt_https_pkg }}"
   when: ansible_os_family == "Debian" and passenger_nginx_apt_https
 
 - name: configure passenger nginx apt key
   apt_key:
-    keyserver="{{ passenger_nginx_apt_key_server }}"
-    id="{{ passenger_nginx_apt_key_id }}"
-    state=present
+    keyserver: "{{ passenger_nginx_apt_key_server }}"
+    id: "{{ passenger_nginx_apt_key_id }}"
+    state: present
   when: ansible_os_family == "Debian" and passenger_nginx_apt_gpg
 
 - name: configure passenger nginx apt repository
   apt_repository:
-    repo="deb {{ passenger_nginx_apt_baseurl }} {{ passenger_nginx_apt_os_version }} {{ passenger_nginx_apt_release }}"
-    state=present
+    repo: "deb {{ passenger_nginx_apt_baseurl }} {{ passenger_nginx_apt_os_version }} {{ passenger_nginx_apt_release }}"
+    state: present
   when: ansible_os_family == "Debian"
 
 - name: configure passenger nginx rpm key
   rpm_key:
-    key="{{ passenger_nginx_yum_key }}"
-    state=present
+    key: "{{ passenger_nginx_yum_key }}"
+    state: present
   when: ansible_os_family == "RedHat" and passenger_nginx_yum_gpg
 
 - name: configure passenger nginx yum repository
   template:
-    src=passenger_nginx.repo.j2
-    dest=/etc/yum.repos.d/passenger_nginx.repo
+    src: passenger_nginx.repo.j2
+    dest: /etc/yum.repos.d/passenger_nginx.repo
   when: ansible_os_family == "RedHat"
 
 - name: configure redhat epel yum repository
   package:
-    name="https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-    state=present
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+    state: present
   when: ansible_distribution == "RedHat" and passenger_nginx_epel
 
 - name: configure centos epel yum repository
   package:
-    name=epel-release
-    state=present
+    name: epel-release
+    state: present
   when: ansible_distribution == "CentOS" and passenger_nginx_epel
 
 - name: configure epel rpm key
   rpm_key:
-    key="/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-    state=present
+    key: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+    state: present
   when: ansible_os_family == "RedHat" and passenger_nginx_epel

--- a/ansible/roles/sqlite/tasks/main.yml
+++ b/ansible/roles/sqlite/tasks/main.yml
@@ -7,13 +7,13 @@
 
 - name: install sqlite
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ sqlite_pkg }}"
 
 - name: create sqlite db directory
   file:
-    path="{{ sqlite_db_dir }}"
-    mode=0755
-    state=directory
+    path: "{{ sqlite_db_dir }}"
+    mode: 0755
+    state: directory
   when: sqlite_db_create_dir

--- a/ansible/roles/tftp/tasks/configuration.yml
+++ b/ansible/roles/tftp/tasks/configuration.yml
@@ -1,60 +1,60 @@
 ---
 - name: add tftp group
   group:
-    name="{{ tftp_group }}"
-    system=yes
-    state=present
+    name: "{{ tftp_group }}"
+    system: yes
+    state: present
 
 - name: add tftp user
   user:
-    name="{{ tftp_user }}"
-    group="{{ tftp_group }}"
-    system=yes
-    createhome=no
-    password=!
-    shell=/bin/false
-    state=present
+    name: "{{ tftp_user }}"
+    group: "{{ tftp_group }}"
+    system: yes
+    createhome: no
+    password: !
+    shell: /bin/false
+    state: present
 
 - name: create tftp directory
   file:
-    path="{{ tftp_dir }}"
-    mode=0755
-    state=directory
+    path: "{{ tftp_dir }}"
+    mode: 0755
+    state: directory
  
 - name: create tftp pxe directories
   file:
-    path="{{ tftp_dir }}/{{ item }}"
-    mode=0755
-    state=directory
+    path: "{{ tftp_dir }}/{{ item }}"
+    mode: 0755
+    state: directory
   with_items: "{{ tftp_pxe_dir }}"
 
 - name: copy syslinux binaries to tftp directory
   copy:
-    src="{{ item }}"
-    dest="{{ tftp_dir }}"
-    remote_src=yes
-    mode=0644
+    src: "{{ item }}"
+    dest: "{{ tftp_dir }}"
+    remote_src: yes
+    mode: 0644
   with_items: "{{ tftp_syslinux_binary }}"
 
 - name: template tftpd-hpa config
   template:
-    src=default_tftpd_hpa.j2
-    dest=/etc/default/tftpd-hpa
-    backup=yes
+    src: default_tftpd_hpa.j2
+    dest: /etc/default/tftpd-hpa
+    backup: yes
   notify:
     - restart tftp
   when: ansible_os_family == "Debian"
 
 - name: template xinetd tftp config
   template:
-    src=xinetd_tftp.j2
-    dest=/etc/xinetd.d/tftp
-    backup=yes
+    src: xinetd_tftp.j2
+    dest: /etc/xinetd.d/tftp
+    backup: yes
   notify:
     - restart tftp
   when: ansible_os_family == "RedHat"
 
 - name: start tftp service
   service:
-    name="{{ tftp_service }}"
-    state=started
+    name: "{{ tftp_service }}"
+    state: started

--- a/ansible/roles/tftp/tasks/installation.yml
+++ b/ansible/roles/tftp/tasks/installation.yml
@@ -1,11 +1,11 @@
 ---
 - name: install tftp
   package:
-    name="{{ item }}"
-    state=present
+    name: "{{ item }}"
+    state: present
   with_items: "{{ tftp_pkg }}"
 
 - name: enable tftp service
   service:
-    name="{{ tftp_service }}"
-    enabled=yes
+    name: "{{ tftp_service }}"
+    enabled: yes


### PR DESCRIPTION
To align with our standard in other projects I've hacked together a quick bash oneliner to upgrade most Ansible tasks to the recommended format:

```
find -type f -path '**/tasks/*.yml' | xargs sed -i 's/\([a-z0-9]\)=/\1: /'
```